### PR TITLE
Feature/error update

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ _Numbers show: (1) The URL and method of the REST API resource, (2) the HTTP cal
    Notice: Specified for component REQUEST_TIMEOUT enviroment variable would be overwritten by specified value of Request timeout, default value would be also overwritten
 - `responseToSnapshotTransform` - This is a JSONata applied to the REST response body and stored in the snapshot as an object.
 
-4. `Snapshot in URL tranform` - If a snapshot value is available it is added into the msg.data object as `msg.data.oihsnapshot`. This can be used in conjuction with the `responseToSnapshotTransform` to perform paging. You can save information for the next page from the response in the snapshot and then use the snapshot information in the next request URL.
+- `Snapshot in URL tranform` - If a snapshot value is available it is added into the msg.data object as `msg.data.oihsnapshot`. This can be used in conjuction with the `responseToSnapshotTransform` to perform paging. You can save information for the next page from the response in the snapshot and then use the snapshot information in the next request URL.
+
+- `Save Received Data` - If enabled, returned message will include the data received by the REST component and the resulting data.
 
 ## Authorisation methods
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -484,8 +484,11 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
         errorMessage: e.message,
         errorStack: e.stack,
       };
-      emitter.logger.debug('Component output: %o', output);
-      await emitter.emit('data', messages.newMessage(output));
+
+      const returnOutput = cfg.saveReceivedData ? output[received] = returnObject.received : output
+      
+      emitter.logger.debug('Component output: %o', returnOutput);
+      await emitter.emit('data', messages.newMessage(returnOutput));
       await rateLimit(emitter.logger, rateLimitDelay);
       await emitter.emit('end');
     } else {


### PR DESCRIPTION
- Updated the error response so if the savedReceivedData config option is enabled, the received data is passed to the returned object
- Added saveReceivedData to README

The savedReceivedData functionality could use improvement - it was a brute force solution to fix the flow issues last week.

https://github.com/blendededge/REST-API-component-oih/blob/dc5b602e9d836850dad63c2ece7e79b91bd6c181/lib/utils.js#L140-L142

If the cfg.saveReceivedData is enabled, then the result of the REST call is added to the object as `response`. 
https://github.com/blendededge/REST-API-component-oih/blob/dc5b602e9d836850dad63c2ece7e79b91bd6c181/lib/utils.js#L223-L226

The returnObject doesn't account for whether or not there's already an existing `received` key, which results in an infinite amount of nested `received`s. ~I think an easy fix would be to change the object to:
const returnObject = {
  received: msg.data.received
}~

The fix would need to be more than that^. Check for a received key, if it exists, replace it, if not, create it.

But you may have a better design idea overall. Hesitant to make changes because Ryan has this component implemented in one of his flows and he accounted for the nested `received`s. 
