### PR TITLE
Feature/ferryman versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY . /usr/src/app
 RUN chown -R node:node .
 
 USER node
-ENTRYPOINT ["node", "./node_modules/@openintegrationhub/ferryman/runGlobal.js"]
+ENTRYPOINT ["./start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine AS base
 RUN apk --no-cache add \
-    python2 \
+    python3 \
     make \
     g++ \
     libc6-compat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine AS base
 RUN apk --no-cache add \
-    python \
+    python2 \
     make \
     g++ \
     libc6-compat

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "Connector"
   ],
   "dependencies": {
-    "@openintegrationhub/ferryman": "~1.7.0",
-    "axios": "^0.21.2",
+    "@openintegrationhub/ferryman": "^2.0.0",
+    "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
+    "axios": "^0.24.0",
     "duplex": "1.0.0",
     "form-data": "^4.0.0",
     "uuid": "^8.3.2"

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# check whether NODE_EXCHANGE is a non-null/non-zero string
+if [ -n "$NODE_EXCHANGE" ]; then
+  # if NODE_EXCHANGE present, run latest version of ferryman
+  node ./node_modules/@openintegrationhub/ferryman/runGlobal.js
+else
+  # if NODE_EXCHANGE not present, run ferryman version 1.7.0 
+  node ./node_modules/@openintegrationhub/ferryman-1-7-0/runGlobal.js
+fi

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# check whether NODE_EXCHANGE is a non-null/non-zero string
-if [ -n "$NODE_EXCHANGE" ]; then
-  # if NODE_EXCHANGE present, run latest version of ferryman
+# check whether ELASTICIO_NODE_EXCHANGE is a non-null/non-zero string
+if [ -n "$ELASTICIO_NODE_EXCHANGE" ]; then
+  # if ELASTICIO_NODE_EXCHANGE present, run latest version of ferryman
   node ./node_modules/@openintegrationhub/ferryman/runGlobal.js
 else
-  # if NODE_EXCHANGE not present, run ferryman version 1.7.0 
+  # if ELASTICIO_NODE_EXCHANGE not present, run ferryman version 1.7.0 
   node ./node_modules/@openintegrationhub/ferryman-1-7-0/runGlobal.js
 fi


### PR DESCRIPTION
The PR checks for an environment variable `NODE_EXCHANGE`, and if found uses version `^2.0.0` of Ferryman, otherwise Ferryman version `^1.7.0` is used. Note that a `NODE_EXCHANGE` value of an empty string will be treated as the variable not existing.

It also upgrades axios from `^0.20.0` to `^0.24.0`.