### PR TITLE
Attachment support

### DIFF
--- a/lib/AttachmentProcessor.js
+++ b/lib/AttachmentProcessor.js
@@ -5,7 +5,7 @@ const REQUEST_TIMEOUT = process.env.REQUEST_TIMEOUT ? parseInt(process.env.REQUE
 const REQUEST_MAX_RETRY = process.env.REQUEST_MAX_RETRY ? parseInt(process.env.REQUEST_MAX_RETRY, 10) : 7; // 10s
 const REQUEST_RETRY_DELAY = process.env.REQUEST_RETRY_DELAY ? parseInt(process.env.REQUEST_RETRY_DELAY, 10) : 7000; // 7s
 const REQUEST_MAX_CONTENT_LENGTH = process.env.REQUEST_MAX_CONTENT_LENGTH ? parseInt(process.env.REQUEST_MAX_CONTENT_LENGTH, 10) : 10485760; // 10MB
-const { ATTACHMENT_STORAGE_SERVICE_BASE_URL } = process.env;
+const ATTACHMENT_STORAGE_SERVICE_BASE_URL = process.env.ATTACHMENT_STORAGE_SERVICE_BASE_URL || 'http://attachment-storage-service.oih-dev-ns.svc.cluster.local:3002';
 
 /**
  * @typedef {import("axios").AxiosResponse} AxiosResponse

--- a/lib/AttachmentProcessor.js
+++ b/lib/AttachmentProcessor.js
@@ -47,7 +47,7 @@ class AttachmentProcessor {
    * @returns {AxiosResponse}
    */
   async uploadAttachment(body, mimeType) {
-    const putUrl = await AttachmentProcessor.preparePutUrl(this.attachmentService);
+    const putUrl = await this.preparePutUrl(this.attachmentService);
     const ax = axios.create();
     AttachmentProcessor.addRetryCountInterceptorToAxios(ax);
 
@@ -69,7 +69,7 @@ class AttachmentProcessor {
     return ax(axConfig);
   }
 
-  static async preparePutUrl(attachmentService) {
+  async preparePutUrl(attachmentService) {
     const service = attachmentService || ATTACHMENT_STORAGE_SERVICE_BASE_URL;
     const signedUrl = `${service}/objects/${uuid.v4()}`;
 

--- a/lib/AttachmentProcessor.js
+++ b/lib/AttachmentProcessor.js
@@ -7,6 +7,10 @@ const REQUEST_RETRY_DELAY = process.env.REQUEST_RETRY_DELAY ? parseInt(process.e
 const REQUEST_MAX_CONTENT_LENGTH = process.env.REQUEST_MAX_CONTENT_LENGTH ? parseInt(process.env.REQUEST_MAX_CONTENT_LENGTH, 10) : 10485760; // 10MB
 const { ATTACHMENT_STORAGE_SERVICE_BASE_URL } = process.env;
 
+/**
+ * @typedef {import("axios").AxiosResponse} AxiosResponse
+ */
+
 // Adapted from https://github.com/elasticio/component-commons-library/blob/master/lib/attachment/AttachmentProcessor.ts
 class AttachmentProcessor {
   constructor(emitter, token, attachmentStorageServiceBaseUrl) {
@@ -36,6 +40,12 @@ class AttachmentProcessor {
     return ax(axConfig);
   }
 
+  /**
+   * Saves a file to the Attachment Storage Service
+   * @param {any} body
+   * @param {string} mimeType
+   * @returns {AxiosResponse}
+   */
   async uploadAttachment(body, mimeType) {
     const putUrl = await AttachmentProcessor.preparePutUrl(this.attachmentService);
     const ax = axios.create();

--- a/lib/actions/httpRequestAction.js
+++ b/lib/actions/httpRequestAction.js
@@ -1,11 +1,11 @@
 const { processMethod } = require('../utils.js');
 
-function processAction(msg, cfg, snapshot) {
+function processAction(msg, cfg, snapshot, headers, tokenData = {}) {
   this.logger.debug('msg:  ', msg);
   this.logger.debug('cfg:  ', cfg);
   this.logger.debug('snapshot: ', snapshot);
-
-  return processMethod.call(this, msg, cfg, snapshot);
+  const TOKEN = cfg.token || tokenData.apiKey;
+  return processMethod.call(this, msg, cfg, snapshot, TOKEN);
 }
 
 exports.process = processAction;

--- a/lib/triggers/httpRequestTrigger.js
+++ b/lib/triggers/httpRequestTrigger.js
@@ -1,11 +1,12 @@
 const { processMethod } = require('../utils.js');
 
-function processTrigger(msg, cfg, snapshot) {
+function processTrigger(msg, cfg, snapshot, headers, tokenData = {}) {
   // eslint-disable-next-line no-param-reassign
   msg.body = {};
   this.logger.debug('msg:  ', msg);
   this.logger.debug('cfg:  ', cfg);
-  return processMethod.call(this, msg, cfg, snapshot);
+  const TOKEN = cfg.token || tokenData.apiKey;
+  return processMethod.call(this, msg, cfg, snapshot, TOKEN);
 }
 
 exports.process = processTrigger;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -289,7 +289,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
    * @param {object} config
    * @param {object} attachments
    */
-  async function processedRequestOperations(data, config) {
+  async function processedRequestOperations(data, config, attachments = {}) {
     emitter.logger.debug('Process response success');
     emitter.logger.debug(`Request output: ${JSON.stringify(data)}`);
 
@@ -297,16 +297,16 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
       // Walk through chain of promises: https://stackoverflow.com/questions/30445543/execute-native-js-promise-in-series
       // eslint-disable-next-line no-restricted-syntax
       for (const item of data) {
-        const output = messages.newMessage(item, msg.attachments);
+        const output = messages.newMessage(item, attachments);
         // eslint-disable-next-line no-await-in-loop
         await emitter.emit('data', output);
       }
     } else if (cfg.saveReceivedData) {
       returnObject.response = data;
-      const output = messages.newMessage(returnObject, msg.attachments);
+      const output = messages.newMessage(returnObject, attachments);
       await emitter.emit('data', output);
     } else {
-      const output = messages.newMessage(data, msg.attachments);
+      const output = messages.newMessage(data, attachments);
       await emitter.emit('data', output);
     }
     // Apply transformation to the response and save the data to the snapshot. Can be used for calculating next page.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -545,7 +545,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
           || contType.includes('msexcel') || contType.includes('pdf')
           || contType.includes('csv') || contType.includes('octet-stream')
           || contType.includes('binary') || contType.includes('jsonl')) {
-      const attachmentProcessor = new AttachmentProcessor(emitter, null, cfg.attachmentServiceUrl);
+      const attachmentProcessor = new AttachmentProcessor(emitter, cfg.token, cfg.attachmentServiceUrl);
       const uploadResponse = await attachmentProcessor.uploadAttachment(response.data, contType);
       emitter.logger.info('Binary data successfully saved to attachments');
       // where is the file saved?

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -279,6 +279,11 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
     }
   }
 
+  /**
+   * Emits the message(s) for the next step
+   * @param {object} data
+   * @param {object} config
+   */
   async function processedRequestOperations(data, config) {
     emitter.logger.debug('Process response success');
     emitter.logger.debug(`Request output: ${JSON.stringify(data)}`);
@@ -472,15 +477,17 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
     return Promise.resolve(requestOptions.data);
   }
 
-  /*
-  * parse response structure
-  *
-  * 1) If body is not exists return empty object {}
-  * 2) If Content-type is exists in response try to parse by content type
-  * 3) If Content-type is not exists try to parse as JSON. If we get parsing error
-  * we should return response as is.
-  *
-  */
+  /**
+   * Converts Axios response object to parsed content
+   * @param {*} response
+   * @returns parsed content
+   * parse response structure
+   *
+   * 1) If body is not exists return empty object {}
+   * 2) If Content-type is exists in response try to parse by content type
+   * 3) If Content-type is not exists try to parse as JSON. If we get parsing error
+   * we should return response as is.
+   */
   async function processResponse(response) {
     emitter.logger.info('HTTP Response headers: %j', response.headers);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,6 +47,10 @@ const contentTypes = {
 const CREDS_HEADER_TYPE = 'CREDS_HEADER_TYPE';
 
 /**
+ * @typedef {import("axios").AxiosResponse} AxiosResponse
+ */
+
+/**
  * Executes the action's/trigger's logic by sending a request to the assigned URL and emitting response to the platform.
  * The function returns a Promise sending a request and resolving the response as platform message.
  *
@@ -283,6 +287,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
    * Emits the message(s) for the next step
    * @param {object} data
    * @param {object} config
+   * @param {object} attachments
    */
   async function processedRequestOperations(data, config) {
     emitter.logger.debug('Process response success');
@@ -479,7 +484,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
 
   /**
    * Converts Axios response object to parsed content
-   * @param {*} response
+   * @param {AxiosResponse} response
    * @returns parsed content
    * parse response structure
    *

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -268,8 +268,9 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
     const data = await sendRequest(requestOptions);
     emitter.logger.debug('Axios call success');
     emitter.logger.trace('Process Response: %o', data);
-    const processedResponse = await processResponse(data);
-    await processedRequestOperations(processedResponse, config);
+    const attachments = {};
+    const processedResponse = await processResponse(data, requestOptions.url, attachments);
+    await processedRequestOperations(processedResponse, config, attachments);
     return processedResponse;
   }
 
@@ -485,6 +486,8 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
   /**
    * Converts Axios response object to parsed content
    * @param {AxiosResponse} response
+   * @param {string} requestUrl
+   * @param {object} attachments
    * @returns parsed content
    * parse response structure
    *
@@ -493,7 +496,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
    * 3) If Content-type is not exists try to parse as JSON. If we get parsing error
    * we should return response as is.
    */
-  async function processResponse(response) {
+  async function processResponse(response, requestUrl, attachments) {
     emitter.logger.info('HTTP Response headers: %j', response.headers);
 
     if (response.data && response.data.byteLength === 0) {
@@ -543,9 +546,17 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
           || contType.includes('csv') || contType.includes('octet-stream')
           || contType.includes('binary') || contType.includes('jsonl')) {
       const attachmentProcessor = new AttachmentProcessor(emitter, null, cfg.attachmentServiceUrl);
-      const attachment = await attachmentProcessor.uploadAttachment(response.data, contType);
+      const uploadResponse = await attachmentProcessor.uploadAttachment(response.data, contType);
       emitter.logger.info('Binary data successfully saved to attachments');
-      return attachment;
+      // where is the file saved?
+      const attachmentUrl = uploadResponse.config.url;
+      // what is the name of the file downloaded? (or the site it was downloaded from)
+      const urlObject = new URL(requestUrl);
+      const fileName = urlObject.pathname.split('/').pop() || urlObject.pathname || requestUrl;
+      attachments[fileName] = {
+        url: attachmentUrl,
+      };
+      return uploadResponse.data;
     }
     emitter.logger.info('Unknown content-type. Trying to parse as JSON');
     return Promise.resolve(response.data);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,7 +59,7 @@ const CREDS_HEADER_TYPE = 'CREDS_HEADER_TYPE';
  * @returns {Object} promise resolving a message to be emitted to the platform
  */
 /* eslint-disable-next-line func-names */
-module.exports.processMethod = async function (msg, cfg, snapshot) {
+module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
   const emitter = this;
 
   emitter.logger.debug('Input message: %o', JSON.stringify(msg));
@@ -381,7 +381,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
           const formData = new FormData();
 
           if (msg.attachments) {
-            const attachmentProcessor = new AttachmentProcessor(emitter, cfg.token, cfg.attachmentServiceUrl);
+            const attachmentProcessor = new AttachmentProcessor(emitter, TOKEN, cfg.attachmentServiceUrl);
             // Add attachments to form data
             const attachments = Object.keys(msg.attachments).map(
               async (key) => {
@@ -545,7 +545,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot) {
           || contType.includes('msexcel') || contType.includes('pdf')
           || contType.includes('csv') || contType.includes('octet-stream')
           || contType.includes('binary') || contType.includes('jsonl')) {
-      const attachmentProcessor = new AttachmentProcessor(emitter, cfg.token, cfg.attachmentServiceUrl);
+      const attachmentProcessor = new AttachmentProcessor(emitter, TOKEN, cfg.attachmentServiceUrl);
       const uploadResponse = await attachmentProcessor.uploadAttachment(response.data, contType);
       emitter.logger.info('Binary data successfully saved to attachments');
       // where is the file saved?


### PR DESCRIPTION
Changes:
- when this component downloads an attachment it will now forward information about that saved record in the message's `attachments` object
- `ATTACHMENT_STORAGE_SERVICE_BASE_URL` defaults to Kubernetes DNS for the Attachment Storage Service but can be overridden by environment variable
- `AttachmentProcessor.preparePutUrl()` is no longer a static method (prevents error when trying to access `this.emitter.logger`)
- the token for saving attachments is taken by default from the component orchestrator, but can be overridden by `fields.token` property on node.
- return type of `processResponse()` is now always the data from the Axios response (attempts to `JSON.stringify()` the full Axios response was causing errors)