### PR TITLE
Component upgrades

### DIFF
--- a/lib/actions/httpRequestAction.js
+++ b/lib/actions/httpRequestAction.js
@@ -1,5 +1,5 @@
 const { processMethod } = require('../utils.js');
-const { wrapper } = require('ferryman-extensions');
+const { wrapper } = require('@blendededge/ferryman-extensions');
 
 function processAction(msg, cfg, snapshot) {
   const wrapped = wrapper(this, msg, cfg, snapshot);

--- a/lib/actions/httpRequestAction.js
+++ b/lib/actions/httpRequestAction.js
@@ -1,11 +1,13 @@
 const { processMethod } = require('../utils.js');
+const { wrapper } = require('ferryman-extensions');
 
 function processAction(msg, cfg, snapshot) {
+  const wrapped = wrapper(this, msg, cfg, snapshot);
   this.logger.debug('msg:  ', msg);
   this.logger.debug('cfg:  ', cfg);
   this.logger.debug('snapshot: ', snapshot);
 
-  return processMethod.call(this, msg, cfg, snapshot);
+  return processMethod.call(wrapped, msg, cfg, snapshot);
 }
 
 exports.process = processAction;

--- a/lib/triggers/httpRequestTrigger.js
+++ b/lib/triggers/httpRequestTrigger.js
@@ -1,5 +1,5 @@
 const { processMethod } = require('../utils.js');
-const { wrapper } = require('ferryman-extensions');
+const { wrapper } = require('@blendededge/ferryman-extensions');
 
 function processTrigger(msg, cfg, snapshot) {
   const wrapped = wrapper(this, msg, cfg, snapshot);

--- a/lib/triggers/httpRequestTrigger.js
+++ b/lib/triggers/httpRequestTrigger.js
@@ -1,11 +1,13 @@
 const { processMethod } = require('../utils.js');
+const { wrapper } = require('ferryman-extensions');
 
 function processTrigger(msg, cfg, snapshot) {
+  const wrapped = wrapper(this, msg, cfg, snapshot);
   // eslint-disable-next-line no-param-reassign
   msg.body = {};
   this.logger.debug('msg:  ', msg);
   this.logger.debug('cfg:  ', cfg);
-  return processMethod.call(this, msg, cfg, snapshot);
+  return processMethod.call(wrapped, msg, cfg, snapshot);
 }
 
 exports.process = processTrigger;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Connector"
   ],
   "dependencies": {
-    "@blendededge/ferryman-extensions": "^1.0.3",
+    "@blendededge/ferryman-extensions": "^1.0.4",
     "@openintegrationhub/ferryman": "^2.0.0",
     "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
     "axios": "^0.24.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yarn": "1.22.0"
   },
   "author": "Ioannis Lafiotis",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/openintegrationhub/REST-API-component/issues"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "Connector"
   ],
   "dependencies": {
+    "@blendededge/ferryman-extensions": "^1.0.3",
     "@openintegrationhub/ferryman": "^2.0.0",
     "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
     "axios": "^0.24.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@blendededge/ferryman-extensions@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@blendededge/ferryman-extensions/-/ferryman-extensions-1.0.3.tgz#c075e6077f4258defdb3e275afdfac7a45b319b7"
+  integrity sha512-vgb71QkJO4I6eqALj7AQxQeW2qJFutbWDs1gG1Pl7nccadroen7qfLGkMloTWFNkafjsmMqJz8RYI2G9bQraYw==
+  dependencies:
+    lodash "^4.17.21"
+
 "@elastic.io/component-logger@0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@elastic.io/component-logger/-/component-logger-0.0.1.tgz#f71488fe25c4b331b0934115f9ba53bfdf67b341"
@@ -1725,7 +1732,7 @@ lodash.set@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
   integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
-lodash@4.17.21, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@4.17.21, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@blendededge/ferryman-extensions@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/@blendededge/ferryman-extensions/-/ferryman-extensions-1.0.3.tgz#c075e6077f4258defdb3e275afdfac7a45b319b7"
-  integrity sha512-vgb71QkJO4I6eqALj7AQxQeW2qJFutbWDs1gG1Pl7nccadroen7qfLGkMloTWFNkafjsmMqJz8RYI2G9bQraYw==
+"@blendededge/ferryman-extensions@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@blendededge/ferryman-extensions/-/ferryman-extensions-1.0.4.tgz#8990fa21fa7529825ca145966728d858382c2cf2"
+  integrity sha512-XEdrzI8TnOUdFSVF69A0G63jbN0L+NgzHrSZHCx7WKDtyAFuNbbpsIpG0miDZ3EE9JjeVVFrmV6VxjO6thY9SA==
   dependencies:
     lodash "^4.17.21"
 


### PR DESCRIPTION
- Adds the `@blendededge/ferryman-extensions` library to enable passthrough functionality.
- Changes license to `Apache-2.0` to be in line with other components