### PR TITLE
Convert to accepted content type

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,6 +43,24 @@ const contentTypes = {
   HTML: 'text/html',
 };
 
+/**
+ * Valid values for the "Content-Type" header field
+ * when sending an attachment to the Attachment Storage Service
+ */
+ const ALLOWED_CONTENT_TYPES = [
+  'application/octet-stream',
+  'application/json',
+  'application/xml',
+  'text/xml',
+  'text/plain',
+  'text/csv',
+  'text/tsv'
+];
+
+const getValidMimeType = (contentType) => {
+  return ALLOWED_CONTENT_TYPES.includes(contentType) ? contentType : 'application/octet-stream';
+}
+
 // eslint-disable-next-line no-unused-vars
 const CREDS_HEADER_TYPE = 'CREDS_HEADER_TYPE';
 
@@ -546,7 +564,8 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
           || contType.includes('csv') || contType.includes('octet-stream')
           || contType.includes('binary') || contType.includes('jsonl')) {
       const attachmentProcessor = new AttachmentProcessor(emitter, TOKEN, cfg.attachmentServiceUrl);
-      const uploadResponse = await attachmentProcessor.uploadAttachment(response.data, contType);
+      const mimeType = getValidMimeType(contType);
+      const uploadResponse = await attachmentProcessor.uploadAttachment(response.data, mimeType);
       emitter.logger.info('Binary data successfully saved to attachments');
       // where is the file saved?
       const attachmentUrl = uploadResponse.config.url;


### PR DESCRIPTION
The Attachment Storage Service only accepts uploaded attachments with the following content types:
- `application/octet-stream`
- `application/json`
- `application/xml`
- `text/xml`
- `text/plain`
- `text/csv`
- `text/tsv`

If the content type provided does not match one of the above types then `application/octet-stream` will be used.