### PR TITLE
Remove OIH snapshot

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -171,10 +171,17 @@ function getAuthFromSecretConfig(cfg, logger) {
   return returnConfig;
 }
 
+function removeSnapshotFromRequest(request) {
+  const cleanRequest = request;
+  delete cleanRequest.oihsnapshot;
+  return cleanRequest;
+}
+
 exports.sleep = sleep;
 exports.rateLimit = rateLimit;
 exports.getRateLimitDelay = getRateLimitDelay;
 exports.getRequestTimeout = getRequestTimeout;
 exports.encodeWWWFormParam = encodeWWWFormParam;
 exports.getMessageSnapshot = getMessageSnapshot;
+exports.removeSnapshotFromRequest = removeSnapshotFromRequest;
 exports.getAuthFromSecretConfig = getAuthFromSecretConfig;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -172,7 +172,8 @@ function getAuthFromSecretConfig(cfg, logger) {
 }
 
 function removeSnapshotFromRequest(request) {
-  const cleanRequest = request;
+  // deep clone
+  const cleanRequest = JSON.parse(JSON.stringify(request));
   delete cleanRequest.oihsnapshot;
   return cleanRequest;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,6 +15,7 @@ const {
   encodeWWWFormParam,
   getMessageSnapshot,
   getAuthFromSecretConfig,
+  removeSnapshotFromRequest,
 } = require('./helpers');
 
 const HTTP_ERROR_CODE_REBOUND = new Set([408, 423, 429, 500, 502, 503, 504]);
@@ -456,6 +457,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
           { customMapping: body.raw },
         );
         if (typeof requestOptions.data === 'object') {
+          requestOptions.data = removeSnapshotFromRequest(requestOptions.data);
           requestOptions.data = JSON.stringify(requestOptions.data);
         }
         break;


### PR DESCRIPTION
The `oihSnapshot` object was being passed into the request body. Updated component so if the `oihSnapshot` exists in the data, it is removed prior to sending the request. 