### PR TITLE
Parse xml responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The following is a complete list of configuration fields that are available on t
   - 504: Gateway Timeout
   - DNS lookup timeout
 
+- **`explicitArray`** - XML responses are automatically parsed into JSON. When `explicitArray` is set to `true`, child nodes will always be put in an array. When `false` (the default), child nodes will only be put in an array if there is more than one child node.
+
 - **`followRedirect`** - By default the `followRedirect` option is set to to the value `followRedirects` and will allow your API request to follow redirects on the server for up to 5 redirects. If you want disable Follow Redirect functionality, you can set the `followRedirect` option to `doNotFollowRedirects`.
 
 - **`httpReboundErrorCodes`** - Array of error status codes from the API response object which will cause the request to be put in the rebound queue.  Messages in the rebound queue will be retried at a progressively longer interval (15 sec, 30 sec, 1 min, 2 min, 4 min, 8 min, etc.). Setting this value will override default values [408, 423, 429, 500, 502, 503, 504]. You should include those status codes unless you have a reason not to.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len,no-shadow,no-param-reassign,no-underscore-dangle,no-use-before-define,consistent-return,arrow-parens */
 
 const { transform } = require('@openintegrationhub/ferryman');
-
+const xml2js = require('xml2js');
 const axios = require('axios');
 const FormData = require('form-data');
 const { AttachmentProcessor } = require('@blendededge/ferryman-extensions');
@@ -542,25 +542,35 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       }
       return data;
     }
-    // TODO: implement later and add unit tests for XML file
-    // if (contType.includes('xml')) {
-    //   emitter.logger.info('Trying to parse response as XML');
-    //   const parseOptions = {
-    //     trim: false,
-    //     normalize: false,
-    //     explicitArray: false,
-    //     normalizeTags: false,
-    //     attrkey: '_attr',
-    //     tagNameProcessors: [
-    //       (name) => name.replace(':', '-'),
-    //     ],
-    //   };
-    //   return xml2js(response.body, parseOptions)
-    //     .then((result) => {
-    //       emitter.logger.info('Response successfully parsed');
-    //       return result;
-    //     });
-    // }
+
+    if (contType.includes('xml')) {
+      emitter.logger.info('Trying to parse response as XML');
+      const parseOptions = {
+        trim: false,
+        normalize: false,
+        explicitArray: false,
+        normalizeTags: false,
+        attrkey: '_attr',
+        tagNameProcessors: [
+          (name) => name.replace(':', '-'),
+        ],
+      };
+
+      // Always put child nodes in an array if true
+      // Otherwise an array is created only if there is more than one.
+      if ('explicitArray' in cfg) {
+        parseOptions.explicitArray = cfg.explicitArray
+      }
+
+      const parser = new xml2js.Parser(parseOptions);
+
+      return parser.parseStringPromise(response.data)
+        .then((result) => {
+          emitter.logger.info('Response successfully parsed');
+          return result;
+        });
+    }
+
     if (contType.includes('image') || contType.includes('msword')
           || contType.includes('msexcel') || contType.includes('pdf')
           || contType.includes('csv') || contType.includes('octet-stream')

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "axios": "^0.27.2",
     "duplex": "1.0.0",
     "form-data": "^4.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "xml2js": "^0.4.23"
   },
   "devDependencies": {
     "@elastic.io/component-logger": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "dependencies": {
     "@blendededge/ferryman-extensions": "^1.2.1",
-    "@openintegrationhub/ferryman": "^2.1.0",
+    "@openintegrationhub/ferryman": "^2.1.1",
     "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
     "axios": "^0.27.2",
     "duplex": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "Connector"
   ],
   "dependencies": {
-    "@blendededge/ferryman-extensions": "^1.1.2",
+    "@blendededge/ferryman-extensions": "^1.2.1",
     "@openintegrationhub/ferryman": "^2.1.0",
     "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
     "axios": "^0.27.2",

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -974,14 +974,63 @@ describe('httpRequest action', () => {
 
       await processAction.call(emitter, msg, cfg);
       expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal(expectedJSON);
+    });
+    it('Valid XML Response with explicit arrays', async () => {
+      const messagesNewMessageWithBodyStub = stub(
+        messages,
+        'newMessage',
+      ).returns(Promise.resolve());
+      const method = 'POST';
+      const msg = {
+        data: {
+          url: 'http://example.com',
+        },
+      };
 
-      // TODO: Converting xml to JSON appears to have been removed and will need added back in
-      // expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal({
-      //   headers: { "content-type": "application/xml" },
-      //   body: { xml: "foo" },
-      //   statusCode: 200,
-      //   statusMessage: null,
-      // });
+      const cfg = {
+        dontThrowErrorFlg: true,
+        reader: {
+          url: '$$.data.url',
+          method,
+        },
+        auth: {},
+        explicitArray: true
+      };
+
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <note>
+        <to>Tove</to>
+        <from>Jani</from>
+        <heading>Reminder</heading>
+        <body>Don't forget me this weekend!</body>
+      </note>`;
+
+      const expectedJSON = {
+        note: {
+          to: [
+            "Tove"
+          ],
+          from: [
+            "Jani"
+          ],
+          heading: [
+            "Reminder"
+          ],
+          body: [
+            "Don't forget me this weekend!"
+          ]
+        }
+      };
+
+      nock(transform(msg, { customMapping: cfg.reader.url }))
+        .intercept('/', method)
+        .delay(20 + Math.random() * 200)
+        .reply(200, xml, {
+          'Content-Type': 'application/xml',
+        });
+
+      await processAction.call(emitter, msg, cfg);
+      expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal(expectedJSON);
     });
     it('Valid XML Response && dontThrowErrorFlg false', async () => {
       const messagesNewMessageWithBodyStub = stub(
@@ -1031,10 +1080,6 @@ describe('httpRequest action', () => {
       await processAction.call(emitter, msg, cfg);
 
       expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal(expectedJSON);
-      // TODO: Converting to JSON has been removed and needs added back or use the XML component
-      // expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal({
-      //   xml: "foo",
-      // });
     });
     it('Invalid XML Response', async () => {
       const method = 'POST';

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -948,15 +948,32 @@ describe('httpRequest action', () => {
         auth: {},
       };
 
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <note>
+        <to>Tove</to>
+        <from>Jani</from>
+        <heading>Reminder</heading>
+        <body>Don't forget me this weekend!</body>
+      </note>`;
+
+      const expectedJSON = {
+        note: {
+          to: "Tove",
+          from: "Jani",
+          heading: "Reminder",
+          body: "Don't forget me this weekend!"
+        }
+      };
+
       nock(transform(msg, { customMapping: cfg.reader.url }))
         .intercept('/', method)
         .delay(20 + Math.random() * 200)
-        .reply(200, '<xml>foo</xml>', {
+        .reply(200, xml, {
           'Content-Type': 'application/xml',
         });
 
       await processAction.call(emitter, msg, cfg);
-      expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal('<xml>foo</xml>');
+      expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal(expectedJSON);
 
       // TODO: Converting xml to JSON appears to have been removed and will need added back in
       // expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal({
@@ -987,16 +1004,33 @@ describe('httpRequest action', () => {
         auth: {},
       };
 
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+      <note>
+        <to>Tove</to>
+        <from>Jani</from>
+        <heading>Reminder</heading>
+        <body>Don't forget me this weekend!</body>
+      </note>`;
+
+      const expectedJSON = {
+        note: {
+          to: "Tove",
+          from: "Jani",
+          heading: "Reminder",
+          body: "Don't forget me this weekend!"
+        }
+      };
+
       nock(transform(msg, { customMapping: cfg.reader.url }))
         .intercept('/', method)
         .delay(20 + Math.random() * 200)
-        .reply(200, '<xml>foo</xml>', {
+        .reply(200, xml, {
           'Content-Type': 'application/xml',
         });
 
       await processAction.call(emitter, msg, cfg);
 
-      expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal('<xml>foo</xml>');
+      expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal(expectedJSON);
       // TODO: Converting to JSON has been removed and needs added back or use the XML component
       // expect(messagesNewMessageWithBodyStub.lastCall.args[0]).to.deep.equal({
       //   xml: "foo",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,10 +63,10 @@
     requestretry "3.1.0"
     uuid "3.0.1"
 
-"@openintegrationhub/ferryman@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@openintegrationhub/ferryman/-/ferryman-2.1.0.tgz#ec25fc6d01fe627ab8c8afd232d3ed14d7d741c0"
-  integrity sha512-fjLjHaUgDnNxraRDa07G8Jj96wOIHWRneGcFZqF9WfrzN30yckOBfYTdJ1HUauf0sKDi+bp+Dtl/G7Bfg8uGoQ==
+"@openintegrationhub/ferryman@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@openintegrationhub/ferryman/-/ferryman-2.1.1.tgz#9c741a0a2f3ac569ccb71d92838221ea5a624576"
+  integrity sha512-/wMCuOLczuE/iHkxk348KH5n2Fl5ewqXuEbD7GSU98Ukv5rjzcOVbaZUQDczTNuXfwxaxkca8Hh5Rw4MDB4Vcg==
   dependencies:
     amqplib "0.8.0"
     bunyan "1.8.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,12 +23,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@blendededge/ferryman-extensions@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@blendededge/ferryman-extensions/-/ferryman-extensions-1.1.2.tgz#aba1bb11de6c2e2f6b986b9fef67207cb9a95d4e"
-  integrity sha512-ZU7ZXTlJWIQQOEjvsEj/QY7VKk2GykVMTa1+BRqyAjB4LblFxDBQx8ZVqH1aSXKKJhxo8ZG3xEA0l0cb81bYhA==
+"@blendededge/ferryman-extensions@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@blendededge/ferryman-extensions/-/ferryman-extensions-1.2.1.tgz#6c5ab22d2ca856c74e7cd30caed5f3931e6b54d9"
+  integrity sha512-+BhCLacjXzht0bkFODoLqqdn2VzxPc2vjRJ+tSl7tALFxB+wN7L1UQPvqNWCcvxQochrQDhsjGEhLOloXWLK+Q==
   dependencies:
     axios "^0.27.0"
+    events "^3.3.0"
     lodash "^4.17.21"
     uuid "^8.3.2"
 
@@ -1000,6 +1001,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 express@4.17.1:
   version "4.17.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2465,6 +2465,11 @@ safe-json-stringify@~1:
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@>=0.6.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
 "semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
@@ -2945,6 +2950,19 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+xml2js@^0.4.23:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@~2.1.1:
   version "2.1.2"


### PR DESCRIPTION
Changes:
- responses with a content type that includes the string `xml` will be parsed as XML
- if the field `explicitArray` is set to true, child nodes will always be put in an array. When false (the default), child nodes will only be put in an array if there is more than one child node
- updates existing tests
- adds test for `explicitArray`