### PR TITLE
Enhancement/dont throw error flg

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -277,7 +277,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     await emitter.emit('end');
   } catch (e) {
     emitter.logger.debug('Inside catch');
-    emitter.logger.trace('Exception during request(s): ', e);
+    emitter.logger.trace('Exception during request(s): ', JSON.stringify(e));
 
     // TODO: save paging state to snapshot - for resume functionality
     // eslint-disable-next-line no-return-await
@@ -602,12 +602,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       && (reboundErrorCodes.has(e.response.status)
         || e.message.includes('DNS lookup timeout'))
     ) {
-      emitter.logger.info('Component error: %o', {
-        message: e.message,
-        name: e.name,
-        code: e.code,
-        response: e.response 
-      });
+      emitter.logger.info('Component error: %o', JSON.stringify(e))
       emitter.logger.info('Starting rebound');
       await emitter.emit('rebound', e.message);
     } else if (e.response && cfg.dontThrowErrorFlg) {
@@ -620,17 +615,11 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       };
 
       const returnOutput = await cfg.saveReceivedData ? { ...output, received: returnObject.received } : output;
-
       emitter.logger.debug('Component output: %o', returnOutput);
       await emitter.emit('data', messages.newMessage(returnOutput));
       await rateLimit(emitter.logger, rateLimitDelay);
     } else {
-      emitter.logger.error('Component error: %o', {
-        message: e.message,
-        name: e.name,
-        code: e.code,
-        response: e.response 
-      });
+      emitter.logger.error('Component error: %o', JSON.stringify(e));
       if (e.message.indexOf(`timeout of ${requestTimeout}ms exceeded`) >= 0) {
         e.message = `Timeout error! Waiting for response more than ${requestTimeout} ms`;
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -625,7 +625,12 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       await emitter.emit('data', messages.newMessage(returnOutput));
       await rateLimit(emitter.logger, rateLimitDelay);
     } else {
-      emitter.logger.error('Component error: %o', e);
+      emitter.logger.error('Component error: %o', {
+        message: e.message,
+        name: e.name,
+        code: e.code,
+        response: e.response 
+      });
       if (e.message.indexOf(`timeout of ${requestTimeout}ms exceeded`) >= 0) {
         e.message = `Timeout error! Waiting for response more than ${requestTimeout} ms`;
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -602,7 +602,12 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       && (reboundErrorCodes.has(e.response.status)
         || e.message.includes('DNS lookup timeout'))
     ) {
-      emitter.logger.info('Component error: %o', e);
+      emitter.logger.info('Component error: %o', {
+        message: e.message,
+        name: e.name,
+        code: e.code,
+        response: e.response 
+      });
       emitter.logger.info('Starting rebound');
       await emitter.emit('rebound', e.message);
     } else if (e.response && cfg.dontThrowErrorFlg) {
@@ -610,6 +615,8 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
         errorCode: e.response.status,
         errorMessage: e.message,
         errorStack: e.stack,
+        errorData: e.response.data,
+        errorHeaders: e.response.headers
       };
 
       const returnOutput = await cfg.saveReceivedData ? { ...output, received: returnObject.received } : output;

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -39,7 +39,6 @@ describe('httpRequest action', () => {
   });
 
   describe('Dont Throw Error Flag', () => {
-    // (uri, requestBody) => [200, { success: true }]
     it('dontThrowErrorFlg true should return error data and headers', async () => {
       const messagesNewMessageWithBodyStub = stub(
         messages,

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -38,6 +38,49 @@ describe('httpRequest action', () => {
     nock.cleanAll();
   });
 
+  describe('Dont Throw Error Flag', () => {
+    // (uri, requestBody) => [200, { success: true }]
+    it('dontThrowErrorFlg true should return error data and headers', async () => {
+      const messagesNewMessageWithBodyStub = stub(
+        messages,
+        'newMessage',
+      ).returns(Promise.resolve());
+      nock('http://example.com')
+        .get('/YourAccount')
+        .delay(20 + Math.random() * 200)
+        .reply((uri, requestBody) => [404, { headers: ['one'], data: { errorInfo: 'my error' } }]);
+      const method = 'GET';
+      const msg = {
+        data: {
+          url: 'http://example.com/YourAccount',
+        },
+      };
+
+      const cfg = {
+        reader: {
+          url: '$$.data.url',
+          method,
+        },
+        followRedirect: 'followRedirects',
+        dontThrowErrorFlg: true,
+        auth: {},
+      };
+
+      await processAction.call(emitter, msg, cfg);
+      expect(
+        messagesNewMessageWithBodyStub.lastCall.args[0].errorCode
+      ).to.eql(
+        404,
+      );
+      expect(
+        messagesNewMessageWithBodyStub.lastCall.args[0].errorData.data,
+      ).to.eql({ errorInfo: 'my error' });
+      expect(
+        messagesNewMessageWithBodyStub.lastCall.args[0].errorData.headers,
+      ).to.eql(['one']);
+    });
+  })
+
   describe('API key credentials', () => {
     const msg = {
       data: {


### PR DESCRIPTION
- The `dontThrowErrorFlg` now also returns the `response.data` (axios error is data, not body) and `response.headers`. 
- I also updated two logs of the component error. Currently, when this is logged, over 3,000 lines are logged. A lot of this is config info that isn't necessary. Steve and I discussed returning the `message`, `name`, `code`, and `response` properties. The `response` property also contains the `request` so we are not losing any valuable information. The extra noise makes it very difficult to look through REST logs when there was an error. 