### PR TITLE
Enhancement/Enable Rebound

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,7 @@ const {
 } = require('./helpers');
 
 const HTTP_ERROR_CODE_REBOUND = new Set([408, 423, 429, 500, 502, 503, 504]);
+const AXIOS_TIMEOUT_ERROR = 'ECONNABORTED';
 
 const methodsMap = {
   DELETE: 'delete',
@@ -600,7 +601,8 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       e.response
       && cfg.enableRebound
       && (reboundErrorCodes.has(e.response.status)
-        || e.message.includes('DNS lookup timeout'))
+        || e.message.includes('DNS lookup timeout') ||
+        e.code === AXIOS_TIMEOUT_ERROR)
     ) {
       emitter.logger.info('Component error: %o', JSON.stringify(e))
       emitter.logger.info('Starting rebound');

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -770,6 +770,34 @@ describe('httpRequest action', () => {
       );
     });
 
+    it('timeout error && enableRebound true', async () => {
+      const method = 'POST';
+      const msg = {
+        data: {
+          url: 'http://example.com',
+        },
+      };
+
+      const cfg = {
+        enableRebound: true,
+        reader: {
+          url: '$$.data.url',
+          method,
+        },
+        auth: {},
+        requestTimeoutPeriod: 100
+      };
+
+      nock(transform(msg, { customMapping: cfg.reader.url }))
+        .intercept('/', method)
+        .delayConnection(200)
+        .replyWithError('');
+
+      await processAction.call(emitter, msg, cfg).catch((e) => {
+        expect(emitter.emit.withArgs('rebound').callCount).to.be.equal(1);
+      })
+    });
+
     it('jsonata response validator false && enableRebound true', async () => {
       const method = 'POST';
       const msg = {


### PR DESCRIPTION
Added a check for the Axios error code `ECONNABORTED`. Left the DNS check in case any other flows are using it and we aren't aware to prevent a breaking change. I did not write a unit test for this, because I wasn't sure how to force Axios to throw a connection error. Since we aren't actually getting an API response, I couldn't mock an API error. If you have any ideas how to build a unit test for this, let me know.