### PR TITLE
add support for oauth1

### DIFF
--- a/lib/authTypes.js
+++ b/lib/authTypes.js
@@ -3,4 +3,5 @@ exports.authTypes = {
   BASIC: 'Basic Auth',
   API_KEY: 'API Key Auth',
   OAUTH2: 'OAuth2',
+  OAUTH1: 'OAuth1',
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -134,7 +134,7 @@ function getMessageSnapshot(id, sourceSnapshot) {
 
 function getAuthFromSecretConfig(cfg, logger) {
   const {
-    username, passphrase, key, headerName, accessToken, secretAuthTransform,
+    username, passphrase, key, headerName, accessToken, secretAuthTransform, consumerKey, consumerSecret,
   } = cfg;
   const returnConfig = { ...cfg };
   const { auth = {} } = returnConfig;
@@ -159,7 +159,24 @@ function getAuthFromSecretConfig(cfg, logger) {
     auth.apiKey.headerName = headerName;
     auth.apiKey.headerValue = key;
   }
-  // Found an accessToken from OA1_TWO_LEGGED, OA1_THREE_LEGGED, OA2_AUTHORIZATION_CODE, or SESSION_AUTH types
+
+  // Found consumerKey and consumerSecret from OA1_TWO_LEGGED or OA1_THREE_LEGGED types
+  if (consumerKey && consumerSecret) {
+    auth.type = authTypes.OAUTH1;
+    auth.oauth1 = {
+      consumerKey,
+      consumerSecret,
+      signatureMethod: cfg.signatureMethod,
+      accessToken,
+      accessTokenSecret: cfg.accessTokenSecret,
+      realm: cfg.realm,
+      version: cfg.version,
+    };
+    returnConfig.auth = auth;
+    return returnConfig;
+  }
+
+  // Found an accessToken from OA2_AUTHORIZATION_CODE or SESSION_AUTH types
   if (accessToken) {
     auth.type = authTypes.OAUTH2;
     auth.oauth2 = auth.oauth2 ? auth.oauth2 : {};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ const xml2js = require('xml2js');
 const axios = require('axios');
 const FormData = require('form-data');
 const { AttachmentProcessor } = require('@blendededge/ferryman-extensions');
+const addOAuthIntercepter = require('axios-oauth-1.0a').default;
 const messages = require('./messages');
 const { authTypes } = require('./authTypes');
 
@@ -89,6 +90,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
   const returnObject = {
     received: msg.data,
   };
+  let oauth1Config;
 
   try {
     emitter.logger.debug('Input message: %o', JSON.stringify(msg));
@@ -204,7 +206,25 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
             value: `"Bearer ${bearerToken}"`,
           });
           break;
+        case authTypes.OAUTH1:
+          emitter.logger.trace('using OAuth1');
+          oauth1Config = {
+            algorithm: auth.oauth1.signatureMethod,
+            key: auth.oauth1.consumerKey,
+            secret: auth.oauth1.consumerSecret,
+            token: auth.oauth1.accessToken,
+            version: auth.oauth1.version,
+          };
+          if (auth.oauth1.accessTokenSecret) {
+            oauth1Config.tokenSecret = auth.oauth1.accessTokenSecret;
+          }
+          if (auth.oauth1.realm) {
+            oauth1Config.realm = auth.oauth1.realm;
+          }
+
+          break;
         default:
+          emitter.logger.warn(`unknown auth type: ${auth.type}`);
       }
     }
 
@@ -249,7 +269,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
         emitter.logger.trace('Paging: Request data: %o', requestOptions.data);
         emitter.logger.debug('Paging: This is the transformed url:', requestOptions.url);
         // eslint-disable-next-line no-await-in-loop
-        const data = await request(requestOptions, config);
+        const data = await request(requestOptions, config, oauth1Config);
         emitter.logger.debug(`Paging: Data for lastPageValidator is ${JSON.stringify(data)}`);
         // Is this the last page? Should evaluate to a boolean
         lastPage = transform(data, { customMapping: config.lastPageValidator });
@@ -275,7 +295,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       emitter.logger.debug('Paging: Successfully emitted all pages. Clearing snapshot');
       emitter.emit('snapshot', {});
     } else {
-      await request(requestOptions, config);
+      await request(requestOptions, config, oauth1Config);
     }
     await emitter.emit('end');
   } catch (e) {
@@ -287,8 +307,8 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     return await buildErrorStructure(e);
   }
 
-  async function request(requestOptions, config) {
-    const data = await sendRequest(requestOptions);
+  async function request(requestOptions, config, oauth1Config = false) {
+    const data = await sendRequest(requestOptions, oauth1Config);
     emitter.logger.debug('Axios call success');
     emitter.logger.trace('Process Response: %o', data);
     const attachments = {};
@@ -297,10 +317,15 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     return processedResponse;
   }
 
-  async function sendRequest(requestOptions) {
+  async function sendRequest(requestOptions, oauth1Config) {
     emitter.logger.debug('Prior to axios call');
     emitter.logger.trace('Request body: %o', requestOptions.data);
     try {
+      if (oauth1Config) {
+        const axiosClient = axios.create();
+        addOAuthIntercepter(axiosClient, oauth1Config);
+        return axiosClient(requestOptions);
+      }
       return axios(requestOptions);
     } catch (e) {
       emitter.logger.trace('Error in axios call: %o', e);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -224,7 +224,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
 
           break;
         default:
-          emitter.logger.warn(`unknown auth type: ${auth.type}`);
+          emitter.logger.info(`unknown or nonexistent auth type: ${auth.type}`);
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,9 @@
       }
     },
     "node_modules/@blendededge/ferryman-extensions/node_modules/jsonata": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.3.tgz",
-      "integrity": "sha512-Up2H81MUtjqI/dWwWX7p4+bUMfMrQJVMN/jW6clFMTiYP528fBOBNtRu944QhKTs3+IsVWbgMeUTny5fw2VMUA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-2.0.5.tgz",
+      "integrity": "sha512-wEse9+QLIIU5IaCgtJCPsFi/H4F3qcikWzF4bAELZiRz08ohfx3Q6CjDRf4ZPF5P/92RI3KIHtb7u3jqPaHXdQ==",
       "engines": {
         "node": ">= 8"
       }
@@ -296,9 +296,9 @@
       }
     },
     "node_modules/@openintegrationhub/ferryman": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@openintegrationhub/ferryman/-/ferryman-2.3.1.tgz",
-      "integrity": "sha512-+e0rezB6s9dGtx45gjcw+UqmnK6c+B8NDtxGanyOipoy0T2lCyjVdz0fdear0zUPBKk49kf1YcTYE6xyCqUUdg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@openintegrationhub/ferryman/-/ferryman-2.4.4.tgz",
+      "integrity": "sha512-7oT2p061OCSNdf54Ql6Dweb4xZ9e4wzJlyDo9TuTDQlY8vqegrp/gafveGQw2bTR5tZpx6Ilw96MJ64IiaZj3g==",
       "dependencies": {
         "amqplib": "0.8.0",
         "bunyan": "1.8.10",
@@ -1102,11 +1102,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.1.tgz",
-      "integrity": "sha512-Q28iYCWzNHjAm+yEAot5QaAMxhMghWLFVf7rRdwhUI+c2jix2DUXjAHXVi+s1ibs3mjPO/cCgbA++3BjD0vP/A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -1209,12 +1209,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2548,9 +2548,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -2675,9 +2675,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -3525,9 +3525,9 @@
       }
     },
     "node_modules/jsonata": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.6.tgz",
-      "integrity": "sha512-ZH2TPYdNP2JecOl/HvrH47Xc+9imibEMQ4YqKy/F/FrM+2a6vfbGxeCX23dB9Fr6uvGwv+ghf1KxWB3iZk09wA==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/jsonata/-/jsonata-1.8.7.tgz",
+      "integrity": "sha512-tOW2/hZ+nR2bcQZs+0T62LVe5CHaNa3laFFWb/262r39utN6whJGBF7IR2Wq1QXrDbhftolk5gggW8uUJYlBTQ==",
       "engines": {
         "node": ">= 8"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@openintegrationhub/ferryman": "^2.3.1",
         "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
         "axios": "^1.5.1",
+        "axios-oauth-1.0a": "^0.3.6",
         "duplex": "1.0.0",
         "form-data": "^4.0.0",
         "uuid": "^9.0.1",
@@ -1108,6 +1109,17 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-oauth-1.0a": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/axios-oauth-1.0a/-/axios-oauth-1.0a-0.3.6.tgz",
+      "integrity": "sha512-WJqWaZ4JXsz31F38tljTZ8p+dGuTV8h7mjEpkZJuaEluR8NILvkFuHLSD9XPL0RLwThNe01tr8HXsiSJk8DNLg==",
+      "dependencies": {
+        "oauth-sign": "^0.9.0"
+      },
+      "peerDependencies": {
+        "axios": ">=0.21.0"
       }
     },
     "node_modules/axobject-query": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@openintegrationhub/ferryman": "^2.3.1",
     "@openintegrationhub/ferryman-1-7-0": "npm:@openintegrationhub/ferryman@^1.7.0",
     "axios": "^1.5.1",
+    "axios-oauth-1.0a": "^0.3.6",
     "duplex": "1.0.0",
     "form-data": "^4.0.0",
     "uuid": "^9.0.1",


### PR DESCRIPTION
Adds support for OAuth1 authentication, making use of the `OA1_TWO_LEGGED` secret type updated in https://github.com/blendededge/openintegrationhub/pull/4

The `OA1_TWO_LEGGED` secret type is identified by the presence of `consumerSecret` and `consumerKey`, and the relevant values are saved in a `oauth1Config` which is otherwise undefined.

When it comes time to make a request, if the `oauth1Config` exists then an axios instance will be created, and an oauth intercepter will be added to perform the OAuth1 signature for the request.

If no `oauth1Config` is present, then an axios instance will not be created (creating an axios instance involves some overhead).

The `realm` and `tokenSecret` fields are optional, and only added to the configuration when present in the OIH secret.

Tested locally (minikube) on a simple 2 step flow, where the first step fetched data from NetSuite (using OAuth1 auth), and the second step sent the result to webhook.site (without any auth).

- Secret Service image used: `stephenhyde2112/secret-service:test-oa1-v2`
- REST Component image used: `stephenhyde2112/rest-api-component-oih:test-oauth-v3`