### PR TITLE
build for linux/amd64 and linux/arm64

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -52,7 +54,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -60,3 +62,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -56,7 +58,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -64,6 +66,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
       - run: git push
         env:
           # The secret is passed automatically. Nothing to configure.


### PR DESCRIPTION
Ensures that docker images built via Github Actions will be available for both `linux/amd64` and `linux/arm64` (enables running locally on Apple Silicon devices)

Tested the build actions in a fork of this repo:
https://github.com/BirdHighway/REST-API-component-oih