### PR TITLE
Emit HTTP Response Information

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -606,6 +606,13 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
         ],
       };
 
+      emitter.emit('trace:http-response', {
+        data: response.data,
+        headers: response.headers,
+        status: response.status,
+        url: requestUrl,
+      });
+
       // Always put child nodes in an array if true
       // Otherwise an array is created only if there is more than one.
       if ('explicitArray' in cfg) {
@@ -637,8 +644,26 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
       attachments[fileName] = {
         url: attachmentUrl,
       };
+      // not the actual data itself, just the metadata
+      emitter.emit('trace:http-response', {
+        data: {
+          url: attachmentUrl,
+          filename: fileName,
+          contentType: mimeType,
+          size: response.data.length,
+        },
+        headers: response.headers,
+        status: response.status,
+        url: requestUrl,
+      });
       return uploadResponse.data;
     }
+    emitter.emit('trace:http-response', {
+      data: response.data,
+      headers: response.headers,
+      status: response.status,
+      url: requestUrl,
+    });
     emitter.logger.info('Unknown content-type. Trying to parse as JSON');
     return Promise.resolve(response.data);
   }
@@ -652,6 +677,15 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
         headers: e.response && e.response.headers,
         status: e.response && e.response.status,
         url: e.response && e.response.config && e.response.config.url,
+      });
+    } else {
+      // Add trace for any errors without response object
+      emitter.emit('trace:http-response', {
+        data: null,
+        headers: null,
+        status: e.code || 'ERROR',
+        url: requestOptions && requestOptions.url,
+        error: e.message,
       });
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -305,10 +305,15 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     // TODO: save paging state to snapshot - for resume functionality
     // eslint-disable-next-line no-return-await
     return await buildErrorStructure(e);
-
   }
 
   async function request(requestOptions, config, oauth1Config = false) {
+    emitter.emit('trace:http-request', {
+      method: requestOptions.method,
+      url: requestOptions.url,
+      headers: requestOptions.headers,
+      data: requestOptions.data,
+    });
     const data = await sendRequest(requestOptions, oauth1Config);
     emitter.logger.debug('Axios call success');
     emitter.logger.trace('Process Response: %o', data);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -647,10 +647,10 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     emitter.logger.debug(`Configured http error status codes for rebound are ${Array.from(reboundErrorCodes.values())}`);
     if (e.response) {
       emitter.emit('trace:http-response', {
-        data: e.response.data,
-        headers: e.response.headers,
-        status: e.response.status,
-        url: e.response.config.url,
+        data: e.response && e.response.data,
+        headers: e.response && e.response.headers,
+        status: e.response && e.response.status,
+        url: e.response && e.response.config && e.response.config.url,
       });
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -556,6 +556,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
   async function processResponse(response, requestUrl, attachments) {
     emitter.logger.info('HTTP Response headers: %j', response.headers);
 
+    // will only be logged if response.data is a buffer (binary data), but not if it's a different content type like text, xml, json, etc.
     if (response.data && response.data.byteLength === 0) {
       emitter.logger.debug('Response size was 0. Returning empty object');
       emitter.emit('trace:http-response', {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -552,6 +552,12 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
 
     if (response.data && response.data.byteLength === 0) {
       emitter.logger.debug('Response size was 0. Returning empty object');
+      emitter.emit('trace:http-response', {
+        data: null,
+        headers: response.headers,
+        status: response.status,
+        url: requestUrl,
+      });
       return Promise.resolve({});
     }
 
@@ -560,6 +566,12 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     emitter.logger.debug('Response content type: %o', contType);
     if (!contType || (contType && contType.includes('json') && !contType.includes('jsonl'))) {
       const data = await Promise.resolve(response.data);
+      emitter.emit('trace:http-response', {
+        data,
+        headers: response.headers,
+        status: response.status,
+        url: requestUrl,
+      });
       emitter.logger.info('HTTP Response body1: %o', data);
       if (jsonataResponseValidator) {
         const valid = transform(data, { customMapping: jsonataResponseValidator });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -305,6 +305,7 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
     // TODO: save paging state to snapshot - for resume functionality
     // eslint-disable-next-line no-return-await
     return await buildErrorStructure(e);
+
   }
 
   async function request(requestOptions, config, oauth1Config = false) {
@@ -639,6 +640,15 @@ module.exports.processMethod = async function (msg, cfg, snapshot, TOKEN) {
   async function buildErrorStructure(e) {
     const reboundErrorCodes = httpReboundErrorCodes ? new Set(httpReboundErrorCodes) : HTTP_ERROR_CODE_REBOUND;
     emitter.logger.debug(`Configured http error status codes for rebound are ${Array.from(reboundErrorCodes.values())}`);
+    if (e.response) {
+      emitter.emit('trace:http-response', {
+        data: e.response.data,
+        headers: e.response.headers,
+        status: e.response.status,
+        url: e.response.config.url,
+      });
+    }
+
     if (
       e.response
       && cfg.enableRebound

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -68,7 +68,7 @@ describe('httpRequest action', () => {
 
       await processAction.call(emitter, msg, cfg);
       expect(
-        messagesNewMessageWithBodyStub.lastCall.args[0].errorCode
+        messagesNewMessageWithBodyStub.lastCall.args[0].errorCode,
       ).to.eql(
         404,
       );
@@ -79,7 +79,7 @@ describe('httpRequest action', () => {
         messagesNewMessageWithBodyStub.lastCall.args[0].errorData.headers,
       ).to.eql(['one']);
     });
-  })
+  });
 
   describe('API key credentials', () => {
     const msg = {
@@ -800,7 +800,7 @@ describe('httpRequest action', () => {
           method,
         },
         auth: {},
-        requestTimeoutPeriod: 100
+        requestTimeoutPeriod: 100,
       };
 
       nock(transform(msg, { customMapping: cfg.reader.url }))
@@ -810,7 +810,7 @@ describe('httpRequest action', () => {
 
       await processAction.call(emitter, msg, cfg).catch((e) => {
         expect(emitter.emit.withArgs('rebound').callCount).to.be.equal(1);
-      })
+      });
     });
 
     it('jsonata response validator false && enableRebound true', async () => {
@@ -841,6 +841,17 @@ describe('httpRequest action', () => {
         .delay(20 + Math.random() * 200)
         .reply((uri, requestBody) => [200, responseMessage]);
 
+      // Mock the buildErrorStructure function or ensure it has the required data
+      const errorObj = {
+        message: {
+          url: 'http://example.com',
+          method,
+          reason: 'JSONata validation against response failed and request should be retried in rebound queue',
+        },
+      };
+
+      // Stub the emit method for rebound to return the error object
+      emitter.emit.withArgs('rebound').returns(Promise.resolve(errorObj));
 
       await processAction.call(emitter, msg, cfg);
       expect(emitter.emit.withArgs('rebound').callCount).to.be.equal(1);
@@ -872,7 +883,6 @@ describe('httpRequest action', () => {
         .intercept('/', method)
         .delay(20 + Math.random() * 200)
         .reply(404);
-
 
       await processAction.call(emitter, msg, cfg);
       expect(emitter.emit.withArgs('rebound').callCount).to.be.equal(1);
@@ -1051,11 +1061,11 @@ describe('httpRequest action', () => {
 
       const expectedJSON = {
         note: {
-          to: "Tove",
-          from: "Jani",
-          heading: "Reminder",
-          body: "Don't forget me this weekend!"
-        }
+          to: 'Tove',
+          from: 'Jani',
+          heading: 'Reminder',
+          body: "Don't forget me this weekend!",
+        },
       };
 
       nock(transform(msg, { customMapping: cfg.reader.url }))
@@ -1088,7 +1098,7 @@ describe('httpRequest action', () => {
           method,
         },
         auth: {},
-        explicitArray: true
+        explicitArray: true,
       };
 
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
@@ -1102,18 +1112,18 @@ describe('httpRequest action', () => {
       const expectedJSON = {
         note: {
           to: [
-            "Tove"
+            'Tove',
           ],
           from: [
-            "Jani"
+            'Jani',
           ],
           heading: [
-            "Reminder"
+            'Reminder',
           ],
           body: [
-            "Don't forget me this weekend!"
-          ]
-        }
+            "Don't forget me this weekend!",
+          ],
+        },
       };
 
       nock(transform(msg, { customMapping: cfg.reader.url }))
@@ -1158,11 +1168,11 @@ describe('httpRequest action', () => {
 
       const expectedJSON = {
         note: {
-          to: "Tove",
-          from: "Jani",
-          heading: "Reminder",
-          body: "Don't forget me this weekend!"
-        }
+          to: 'Tove',
+          from: 'Jani',
+          heading: 'Reminder',
+          body: "Don't forget me this weekend!",
+        },
       };
 
       nock(transform(msg, { customMapping: cfg.reader.url }))
@@ -1522,9 +1532,9 @@ describe('httpRequest action', () => {
         });
 
       await processAction.call(emitter, msg, cfg);
-      expect(emitter.emit.callCount).to.equal(2);
-      expect(emitter.emit.args[0][0]).to.equal('error');
-      expect(emitter.emit.args[1][0]).to.equal('end');
+      expect(emitter.emit.callCount).to.equal(4);
+      expect(emitter.emit.args[2][0]).to.equal('error');
+      expect(emitter.emit.args[3][0]).to.equal('end');
     });
     it('redirect request false POST && dontThrowErrorFlg false', async () => {
       const messagesNewMessageWithBodyStub = stub(
@@ -1560,9 +1570,9 @@ describe('httpRequest action', () => {
         });
 
       await processAction.call(emitter, msg, cfg);
-      expect(emitter.emit.callCount).to.equal(2);
-      expect(emitter.emit.args[0][0]).to.equal('error');
-      expect(emitter.emit.args[1][0]).to.equal('end');
+      expect(emitter.emit.callCount).to.equal(4);
+      expect(emitter.emit.args[2][0]).to.equal('error');
+      expect(emitter.emit.args[3][0]).to.equal('end');
     });
     it('redirect request true POST && dontThrowErrorFlg false', async () => {
       const messagesNewMessageWithBodyStub = stub(
@@ -1747,9 +1757,9 @@ describe('httpRequest action', () => {
       };
 
       await processAction.call(emitter, msg, cfg);
-      expect(emitter.emit.callCount).to.equal(2);
-      expect(emitter.emit.args[0][0]).to.equal('error');
-      expect(emitter.emit.args[1][0]).to.equal('end');
+      expect(emitter.emit.callCount).to.equal(4);
+      expect(emitter.emit.args[2][0]).to.equal('error');
+      expect(emitter.emit.args[3][0]).to.equal('end');
     });
   });
 
@@ -1812,8 +1822,8 @@ describe('httpRequest action', () => {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
       await processAction.call(emitter, msg, cfg);
-      expect(emitter.emit.getCall(0).args[0]).to.be.equals('error');
-      expect(emitter.emit.getCall(0).args[1].message).to.be.equals(
+      expect(emitter.emit.getCall(1).args[0]).to.be.equals('error');
+      expect(emitter.emit.getCall(1).args[1].message).to.be.equals(
         `Timeout error! Waiting for response more than ${cfg.requestTimeoutPeriod} ms`,
       );
     });

--- a/test/httpRequestAction.spec.js
+++ b/test/httpRequestAction.spec.js
@@ -1822,8 +1822,8 @@ describe('httpRequest action', () => {
       process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
 
       await processAction.call(emitter, msg, cfg);
-      expect(emitter.emit.getCall(1).args[0]).to.be.equals('error');
-      expect(emitter.emit.getCall(1).args[1].message).to.be.equals(
+      expect(emitter.emit.getCall(2).args[0]).to.be.equals('error');
+      expect(emitter.emit.getCall(2).args[1].message).to.be.equals(
         `Timeout error! Waiting for response more than ${cfg.requestTimeoutPeriod} ms`,
       );
     });

--- a/test/httpRequestTrigger.paging.spec.js
+++ b/test/httpRequestTrigger.paging.spec.js
@@ -284,7 +284,7 @@ describe('httpRequest action paging', () => {
     await processAction.call(emitter, msg, cfg);
     expect(messagesNewMessageWithBodyStub.calledTwice).to.be.true;
     expect(messagesNewMessageWithBodyStub.args[0][0]).to.be.eql(responseMessage);
-    expect(emitter.emit.callCount).to.equal(14);
+    expect(emitter.emit.callCount).to.equal(13);
     expect(emitter.emit.args[0][0]).to.equal('data');
     expect(emitter.emit.args[1][0]).to.equal('snapshot');
     expect(emitter.emit.args[2][0]).to.equal('end');

--- a/test/httpRequestTrigger.paging.spec.js
+++ b/test/httpRequestTrigger.paging.spec.js
@@ -284,7 +284,7 @@ describe('httpRequest action paging', () => {
     await processAction.call(emitter, msg, cfg);
     expect(messagesNewMessageWithBodyStub.calledTwice).to.be.true;
     expect(messagesNewMessageWithBodyStub.args[0][0]).to.be.eql(responseMessage);
-    expect(emitter.emit.callCount).to.equal(9);
+    expect(emitter.emit.callCount).to.equal(14);
     expect(emitter.emit.args[0][0]).to.equal('data');
     expect(emitter.emit.args[1][0]).to.equal('snapshot');
     expect(emitter.emit.args[2][0]).to.equal('end');

--- a/test/httpRequestTrigger.paging.spec.js
+++ b/test/httpRequestTrigger.paging.spec.js
@@ -285,16 +285,20 @@ describe('httpRequest action paging', () => {
     expect(messagesNewMessageWithBodyStub.calledTwice).to.be.true;
     expect(messagesNewMessageWithBodyStub.args[0][0]).to.be.eql(responseMessage);
     expect(emitter.emit.callCount).to.equal(13);
-    expect(emitter.emit.args[0][0]).to.equal('data');
-    expect(emitter.emit.args[1][0]).to.equal('snapshot');
-    expect(emitter.emit.args[2][0]).to.equal('end');
+    expect(emitter.emit.args[0][0]).to.equal('trace:http-request');
+    expect(emitter.emit.args[1][0]).to.equal('trace:http-response');
+    expect(emitter.emit.args[2][0]).to.equal('data');
     expect(emitter.emit.args[3][0]).to.equal('snapshot');
-    expect(emitter.emit.args[4][0]).to.equal('data');
+    expect(emitter.emit.args[4][0]).to.equal('end');
     expect(emitter.emit.args[5][0]).to.equal('snapshot');
-    expect(emitter.emit.args[6][0]).to.equal('end');
-    expect(emitter.emit.args[7][0]).to.equal('snapshot');
-    // Validate end is only called once
-    expect(emitter.emit.args[6][0]).to.equal('end');
+    expect(emitter.emit.args[6][0]).to.equal('trace:http-request');
+    expect(emitter.emit.args[7][0]).to.equal('trace:http-response');
+    expect(emitter.emit.args[8][0]).to.equal('data');
+    expect(emitter.emit.args[9][0]).to.equal('snapshot');
+    expect(emitter.emit.args[10][0]).to.equal('end');
+    expect(emitter.emit.args[11][0]).to.equal('snapshot');
+    expect(emitter.emit.args[12][0]).to.equal('end');
+    // Validate end is called three times in total
   });
 
   it('paging loop, error thrown', async () => {


### PR DESCRIPTION
Emits an event to the trace events array that includes the http response body, headers, status code and the url of the request. It does this on both successes and errors.

Example event data for an error (de-stringified for easier viewing)
```json
{
    "event": {
        "data": {
            "errorMessage": "your request was really bad"
        },
        "headers": {
            "server": "nginx",
            "content-type": "application/json",
            "transfer-encoding": "chunked",
            "x-request-id": "7ea17a26-7716-4cf6-aa8e-c8384d8195f2",
            "x-token-id": "227e6b1a-0b82-4229-87f0-cae3abb9b5b6",
            "cache-control": "no-cache, private",
            "date": "Thu, 03 Apr 2025 19:39:51 GMT",
            "connection": "close"
        },
        "status": 500,
        "url": "https://webhook.site/random-500s"
    }
}
```

How it looks in ClickHouse
<img width="795" alt="Screenshot 2025-04-03 at 3 44 49 PM" src="https://github.com/user-attachments/assets/a099f0db-6cd7-4cf1-8f6b-d6ec4306e9cc" />


Now also includes request info under an event `trace:http-request`
